### PR TITLE
Updated .koinosrc testnet

### DIFF
--- a/docs/modules/M1/2_installation.md
+++ b/docs/modules/M1/2_installation.md
@@ -37,6 +37,7 @@ connect https://harbinger-api.koinos.io/
 register_token koin 1FaSvLjQJsCJKq5ybmGsMMQs8RQYyVv8ju
 register_token vhp 17n12ktwN79sR6ia9DDgCfmw77EgpbTyBi
 register pob 1MAbK5pYkhp9yHnfhYamC3tfSLmVRTDjd9
+register name_service 13NQnca5chwpKm4ebHbvgvJmXrsSCTayDJ
 register resources 16X6cKyqiT8EzPEksRJxXcqMnHMMm9Vxct
 register governance 17MjUXDCuTX1p9Kyqy48SQkkPfKScoggo
 ```
@@ -91,6 +92,9 @@ koin.balance_of                           - Checks the balance at an address
 koin.total_supply                         - Checks the token total supply
 koin.transfer                             - Transfers the token
 list                                      - List available commands
+name_service.get_address                  - Gets the address of a contract registered with the name service
+name_service.get_name                     - Gets the name of a contract registered with the name service
+name_service.set_record                   - Sets a name record in the name service
 nonce                                     - Set nonce for transactions. 'auto' will default to querying for nonce. Blank nonce to view
 open                                      - Open a wallet file (unlock also works)
 payer                                     - Set the payer address for transactions. 'me' will default to current wallet. Blank address to view

--- a/docs/modules/M1/2_installation.md
+++ b/docs/modules/M1/2_installation.md
@@ -91,9 +91,6 @@ koin.balance_of                           - Checks the balance at an address
 koin.total_supply                         - Checks the token total supply
 koin.transfer                             - Transfers the token
 list                                      - List available commands
-name_service.get_address                  - Gets the address of a contract registered with the name service
-name_service.get_name                     - Gets the name of a contract registered with the name service
-name_service.set_record                   - Sets a name record in the name service
 nonce                                     - Set nonce for transactions. 'auto' will default to querying for nonce. Blank nonce to view
 open                                      - Open a wallet file (unlock also works)
 payer                                     - Set the payer address for transactions. 'me' will default to current wallet. Blank address to view

--- a/docs/modules/M4/7_upload-contract.md
+++ b/docs/modules/M4/7_upload-contract.md
@@ -8,7 +8,7 @@ __Remember, if you following this lesson on testnet, use the testnet `koinosrc` 
 From `koinos-cli` open your new wallet address and enter the following command to upload the `.wasm` and `.abi` files we created previously:
 
 ```
-upload myawesomecontract/build/release/contract.asm myawesomecontract/abi/myawesomecontract.abi
+upload myawesomecontract/build/release/contract.wasm myawesomecontract/abi/myawesomecontract.abi
 ```
 
 You will get the following as a response that includes the transaction ID:


### PR DESCRIPTION
Updated the .koinosrc for testnet. One note - I removed the name_service and claim contracts for the testnet one as I did not find the testnet ones yet. I will update this PR if or when I do.